### PR TITLE
Add scoped hash table symbol table with memory checks

### DIFF
--- a/include/memmgr.h
+++ b/include/memmgr.h
@@ -11,7 +11,10 @@ void mm_free(void *ptr);
 void *mm_realloc(void *ptr, size_t new_size);
 
 size_t mm_current_usage(void);
+/* Retorna o limite máximo configurado para o gerenciador */
 size_t mm_max_usage(void);
+/* Retorna o maior pico de uso registrado */
+size_t mm_peak_usage(void);
 
 
 void mm_cleanup(void);

--- a/include/semantics.h
+++ b/include/semantics.h
@@ -9,12 +9,11 @@
 
 typedef struct {
     size_t mem_limit;
-    Scope *global_scope;
+    SymTab *symtab;
 } SemaContext;
 
 SemaContext* sema_create(size_t mem_limit_bytes);
 bool semantic_analyze(SemaContext* sc, ASTNode* ast);
-void symtab_print(SemaContext* sc);
 void sema_destroy(SemaContext* sc);
 
 #endif /* SEMANTICS_H */

--- a/include/symtab.h
+++ b/include/symtab.h
@@ -2,26 +2,51 @@
 #define SYMTAB_H
 
 #include <stddef.h>
+#include <stdbool.h>
+#include "types.h"
 
-/* Símbolo individual */
+/* Classes possíveis de símbolos */
+typedef enum {
+    SYM_VAR,
+    SYM_PARAM,
+    SYM_FUNC
+} SymClass;
+
+/* Estrutura de um símbolo individual */
 typedef struct Symbol {
-    char *name;
-    struct Symbol *next;
+    char *name;            /* nome do símbolo */
+    SymClass sclass;       /* var, param ou func */
+    Type *type;            /* tipo associado */
+    size_t scope_id;       /* escopo onde foi declarado */
+    int line_decl;         /* linha da declaração */
+    void *extra;           /* informação adicional */
+    struct Symbol *next;   /* próximo na lista do bucket */
 } Symbol;
 
-/* Escopo contendo símbolos */
+/* Escopo com tabela de dispersão de símbolos */
 typedef struct Scope {
-    Symbol *symbols;
-    struct Scope *parent;
-    struct Scope *children;
-    struct Scope *next;
-    size_t depth;
+    size_t id;             /* identificador do escopo */
+    Symbol **buckets;      /* buckets da hash table */
+    size_t bucket_count;   /* quantidade de buckets */
+    struct Scope *parent;  /* escopo pai (aninhamento) */
 } Scope;
 
-Scope* scope_create(Scope *parent);
-void scope_destroy(Scope *scope);
-Symbol* symtab_add(Scope *scope, const char *name);
-Symbol* symtab_lookup(Scope *scope, const char *name);
-void symtab_print_scope(Scope *scope, int indent);
+/* Tabela de símbolos contendo pilha de escopos */
+typedef struct SymTab {
+    Scope *current;        /* escopo atual (topo da pilha) */
+    size_t next_id;        /* próximo id de escopo */
+} SymTab;
+
+SymTab* symtab_create(void);
+void symtab_destroy(SymTab *st);
+
+void symtab_enter_scope(SymTab *st);
+void symtab_leave_scope(SymTab *st);
+
+bool symtab_insert(SymTab *st, const Symbol *sym);
+Symbol* symtab_lookup(SymTab *st, const char *name);
+
+void symtab_print(SymTab *st);
 
 #endif /* SYMTAB_H */
+

--- a/src/main.c
+++ b/src/main.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
     } else {
         printf("\033[32mAnálise semântica concluída com sucesso!\033[0m\n");
     }
-    symtab_print(sc);
+    symtab_print(sc->symtab);
     sema_destroy(sc);
 
     /* Limpeza da AST */
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     /* Relatório de memória */
     printf("\n\033[34m=== RELATÓRIO DE MEMÓRIA ===\033[0m\n");
     printf("Uso atual: %zu bytes\n", mm_current_usage());
-    printf("Pico de uso: %zu bytes\n", mm_max_usage());
+    printf("Pico de uso: %zu bytes\n", mm_peak_usage());
     
     mm_cleanup();
 

--- a/src/memmgr.c
+++ b/src/memmgr.c
@@ -103,7 +103,10 @@ void mm_free(void *ptr) {
 }
 
 size_t mm_current_usage(void) { return mm_current; }
-size_t mm_max_usage(void)     { return mm_high_water; }
+/* Limite máximo estabelecido via mm_init */
+size_t mm_max_usage(void) { return mm_limit; }
+/* Maior pico de uso observado */
+size_t mm_peak_usage(void) { return mm_high_water; }
 
 void mm_cleanup(void) {
     BlockHeader *h = mm_head;

--- a/src/semantics.c
+++ b/src/semantics.c
@@ -2,23 +2,33 @@
 #include "memmgr.h"
 #include <stdio.h>
 
-static void analyze_node(SemaContext *sc, ASTNode *node, Scope *scope) {
-    int i;
+static void analyze_node(SemaContext *sc, ASTNode *node) {
     if (!node) return;
+
     switch (node->type) {
         case AST_DECLARATION:
             if (node->child_count > 0) {
                 ASTNode *id = node->children[0];
                 if (id && id->type == AST_IDENTIFIER && id->token.lexeme) {
-                    symtab_add(scope, id->token.lexeme);
+                    Symbol s = {0};
+                    s.name = id->token.lexeme;
+                    s.sclass = SYM_VAR;
+                    s.type = NULL;
+                    s.line_decl = id->token.line;
+                    s.extra = NULL;
+                    symtab_insert(sc->symtab, &s);
                 }
             }
             break;
         default:
             break;
     }
-    for (i = 0; i < node->child_count; i++) {
-        analyze_node(sc, node->children[i], scope);
+
+    {
+        int i;
+        for (i = 0; i < node->child_count; i++) {
+            analyze_node(sc, node->children[i]);
+        }
     }
 }
 
@@ -26,8 +36,8 @@ SemaContext* sema_create(size_t mem_limit_bytes) {
     SemaContext *sc = (SemaContext*)mm_malloc(sizeof(SemaContext));
     if (!sc) return NULL;
     sc->mem_limit = mem_limit_bytes;
-    sc->global_scope = scope_create(NULL);
-    if (!sc->global_scope) {
+    sc->symtab = symtab_create();
+    if (!sc->symtab) {
         mm_free(sc);
         return NULL;
     }
@@ -36,19 +46,13 @@ SemaContext* sema_create(size_t mem_limit_bytes) {
 
 bool semantic_analyze(SemaContext* sc, ASTNode* ast) {
     if (!sc || !ast) return false;
-    analyze_node(sc, ast, sc->global_scope);
+    analyze_node(sc, ast);
     return true;
-}
-
-void symtab_print(SemaContext* sc) {
-    if (!sc) return;
-    printf("\033[34m=== TABELA DE SÍMBOLOS ===\033[0m\n");
-    symtab_print_scope(sc->global_scope, 0);
 }
 
 void sema_destroy(SemaContext* sc) {
     if (!sc) return;
-    scope_destroy(sc->global_scope);
+    symtab_destroy(sc->symtab);
     mm_free(sc);
 }
 

--- a/src/symtab.c
+++ b/src/symtab.c
@@ -2,20 +2,48 @@
 #include "memmgr.h"
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-Scope* scope_create(Scope *parent) {
-    Scope *scope = (Scope*)mm_malloc(sizeof(Scope));
-    if (!scope) return NULL;
-    scope->symbols = NULL;
-    scope->parent = parent;
-    scope->children = NULL;
-    scope->next = NULL;
-    scope->depth = parent ? parent->depth + 1 : 0;
-    if (parent) {
-        scope->next = parent->children;
-        parent->children = scope;
+#define SYMTAB_BUCKETS 64
+
+/* Hash simples para strings (djb2) */
+static unsigned long sym_hash(const char *str) {
+    unsigned long hash = 5381;
+    int c;
+    while ((c = *str++)) {
+        hash = ((hash << 5) + hash) + (unsigned long)c;
     }
-    return scope;
+    return hash;
+}
+
+static Scope* scope_new(size_t id, Scope *parent) {
+    Scope *s = (Scope*)mm_malloc(sizeof(Scope));
+    if (!s) return NULL;
+    s->id = id;
+    s->parent = parent;
+    s->bucket_count = SYMTAB_BUCKETS;
+    s->buckets = (Symbol**)mm_malloc(sizeof(Symbol*) * s->bucket_count);
+    if (!s->buckets) {
+        mm_free(s);
+        return NULL;
+    }
+    {
+        size_t i;
+        for (i = 0; i < s->bucket_count; ++i) s->buckets[i] = NULL;
+    }
+    return s;
+}
+
+SymTab* symtab_create(void) {
+    SymTab *st = (SymTab*)mm_malloc(sizeof(SymTab));
+    if (!st) return NULL;
+    st->next_id = 1; /* global = 0 */
+    st->current = scope_new(0, NULL);
+    if (!st->current) {
+        mm_free(st);
+        return NULL;
+    }
+    return st;
 }
 
 static void free_symbols(Symbol *sym) {
@@ -27,65 +55,144 @@ static void free_symbols(Symbol *sym) {
     }
 }
 
-void scope_destroy(Scope *scope) {
-    if (!scope) return;
-    Scope *child = scope->children;
-    while (child) {
-        Scope *next_child = child->next;
-        scope_destroy(child);
-        child = next_child;
-    }
-    free_symbols(scope->symbols);
-    mm_free(scope);
-}
-
-Symbol* symtab_add(Scope *scope, const char *name) {
-    if (!scope || !name) return NULL;
-    Symbol *sym = (Symbol*)mm_malloc(sizeof(Symbol));
-    if (!sym) return NULL;
-    size_t len = strlen(name);
-    sym->name = (char*)mm_malloc(len + 1);
-    if (!sym->name) {
-        mm_free(sym);
-        return NULL;
-    }
-    strcpy(sym->name, name);
-    sym->next = scope->symbols;
-    scope->symbols = sym;
-    return sym;
-}
-
-Symbol* symtab_lookup(Scope *scope, const char *name) {
-    while (scope) {
-        Symbol *sym = scope->symbols;
-        while (sym) {
-            if (strcmp(sym->name, name) == 0) return sym;
-            sym = sym->next;
+void symtab_leave_scope(SymTab *st) {
+    if (!st || !st->current) return;
+    Scope *to_pop = st->current;
+    st->current = to_pop->parent;
+    {
+        size_t i;
+        for (i = 0; i < to_pop->bucket_count; ++i) {
+            free_symbols(to_pop->buckets[i]);
         }
-        scope = scope->parent;
+    }
+    mm_free(to_pop->buckets);
+    mm_free(to_pop);
+}
+
+void symtab_destroy(SymTab *st) {
+    if (!st) return;
+    while (st->current) symtab_leave_scope(st);
+    mm_free(st);
+}
+
+void symtab_enter_scope(SymTab *st) {
+    if (!st) return;
+    Scope *s = scope_new(st->next_id++, st->current);
+    if (s) st->current = s;
+}
+
+bool symtab_insert(SymTab *st, const Symbol *sym) {
+    if (!st || !st->current || !sym || !sym->name) return false;
+    unsigned long h = sym_hash(sym->name) % st->current->bucket_count;
+
+    /* Verifica se já existe no escopo atual */
+    {
+        Symbol *it;
+        for (it = st->current->buckets[h]; it; it = it->next) {
+            if (strcmp(it->name, sym->name) == 0) return false; /* duplicado */
+        }
+    }
+
+    Symbol *copy = (Symbol*)mm_malloc(sizeof(Symbol));
+    if (!copy) return false;
+    memcpy(copy, sym, sizeof(Symbol));
+
+    size_t len = strlen(sym->name);
+    copy->name = (char*)mm_malloc(len + 1);
+    if (!copy->name) {
+        mm_free(copy);
+        return false;
+    }
+    strcpy(copy->name, sym->name);
+    copy->scope_id = st->current->id;
+    copy->next = st->current->buckets[h];
+    st->current->buckets[h] = copy;
+
+    size_t usage = mm_current_usage();
+    size_t limit = mm_max_usage();
+    if (limit > 0) {
+        if (usage >= limit) {
+            fprintf(stderr, "Memória Insuficiente\n");
+            exit(EXIT_FAILURE);
+        } else if (usage >= (size_t)(0.9 * (double)limit)) {
+            fprintf(stderr, "Alerta: uso de memória entre 90%% e 99%%\n");
+        }
+    }
+    return true;
+}
+
+Symbol* symtab_lookup(SymTab *st, const char *name) {
+    if (!st || !name) return NULL;
+    {
+        Scope *s;
+        for (s = st->current; s; s = s->parent) {
+            unsigned long h = sym_hash(name) % s->bucket_count;
+            Symbol *it;
+            for (it = s->buckets[h]; it; it = it->next) {
+                if (strcmp(it->name, name) == 0) return it;
+            }
+        }
     }
     return NULL;
 }
 
-static void print_scope(const Scope *scope, int indent) {
-    if (!scope) return;
-    int i;
-    for (i = 0; i < indent; i++) printf("  ");
-    printf("Escopo (profundidade %zu)\n", scope->depth);
-    Symbol *sym = scope->symbols;
-    while (sym) {
-        for (i = 0; i < indent + 1; i++) printf("  ");
-        printf("%s\n", sym->name);
-        sym = sym->next;
-    }
-    Scope *child = scope->children;
-    while (child) {
-        print_scope(child, indent + 1);
-        child = child->next;
+static const char* class_str(SymClass c) {
+    switch (c) {
+        case SYM_VAR:   return "var";
+        case SYM_PARAM: return "param";
+        case SYM_FUNC:  return "func";
+        default:        return "?";
     }
 }
 
-void symtab_print_scope(Scope *scope, int indent) {
-    print_scope(scope, indent);
+static const char* type_str(const Type *t) {
+    if (!t) return "?";
+    switch (t->kind) {
+        case TYPE_INT:   return "int";
+        case TYPE_FLOAT: return "float";
+        case TYPE_VOID:  return "void";
+        default:         return "?";
+    }
+}
+
+void symtab_print(SymTab *st) {
+    if (!st) return;
+
+    size_t count = 0;
+    {
+        Scope *s;
+        for (s = st->current; s; s = s->parent) count++;
+    }
+    Scope **order = (Scope**)mm_malloc(sizeof(Scope*) * count);
+    {
+        size_t i = count;
+        Scope *s;
+        for (s = st->current; s; s = s->parent) {
+            order[--i] = s;
+        }
+    }
+
+    {
+        size_t i;
+        for (i = 0; i < count; ++i) {
+            Scope *sc = order[i];
+            printf("Escopo %zu:\n", sc->id);
+            {
+                size_t b;
+                for (b = 0; b < sc->bucket_count; ++b) {
+                    Symbol *sym;
+                    for (sym = sc->buckets[b]; sym; sym = sym->next) {
+                        printf("  %s (%s, %s, linha %d)\n",
+                               sym->name,
+                               class_str(sym->sclass),
+                               type_str(sym->type),
+                               sym->line_decl);
+                    }
+                }
+            }
+            printf("\n");
+        }
+    }
+    mm_free(order);
 }
 


### PR DESCRIPTION
## Summary
- implement hash table-based symbol table with scoped stack and printing
- expose memory manager limit and peak tracking, warn/abort on table insert
- update semantic analyzer and main to use new symbol table

## Testing
- `make`
- `./compiler tests/ex_should_pass` *(fails: "Erro sintático na linha 1: Esperado tipo de variável (inteiro, decimal, texto)")*


------
https://chatgpt.com/codex/tasks/task_e_68ae783f39ec832bb82600dae979fd07