### PR TITLE
Implement basic type system and expression type inference

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -2,6 +2,7 @@
 #define PARSER_H
 
 #include "token.h"
+#include "types.h"
 
 /* Tipos de nós da árvore sintática */
 typedef enum {
@@ -32,6 +33,7 @@ typedef struct ASTNode {
     int child_count;                /* Número de filhos */
     int child_capacity;             /* Capacidade do array de filhos */
     char *value;                    /* Valor opcional do nó */
+    Type inferred_type;             /* Tipo inferido pelo analisador semântico */
 } ASTNode;
 
 /* Estrutura do analisador sintático */

--- a/include/types.h
+++ b/include/types.h
@@ -1,14 +1,35 @@
 #ifndef TYPES_H
 #define TYPES_H
 
+#include <stddef.h>
+
+/* Tipos básicos suportados pelo compilador */
 typedef enum {
-    TYPE_INT,
-    TYPE_FLOAT,
-    TYPE_VOID
+    TY_INT,   /* inteiros */
+    TY_DEC,   /* decimais */
+    TY_TXT,   /* textos */
+    TY_BOOL   /* booleanos */
 } TypeKind;
 
+/* Metadados para o tipo decimal[a.b] */
+typedef struct {
+    int a; /* precisão */
+    int b; /* escala */
+} DecimalInfo;
+
+/* Metadados para o tipo texto[n] */
+typedef struct {
+    size_t n; /* tamanho máximo */
+} TextInfo;
+
+/* Representação de um tipo */
 typedef struct Type {
-    TypeKind kind;
+    TypeKind kind; /* categoria do tipo */
+    union {
+        DecimalInfo dec;
+        TextInfo txt;
+    } info; /* informações adicionais */
 } Type;
 
 #endif /* TYPES_H */
+

--- a/src/parser.c
+++ b/src/parser.c
@@ -47,6 +47,9 @@ ASTNode* ast_node_create(ASTNodeType type, Token token) {
     node->child_count = 0;
     node->child_capacity = 0;
     node->value = NULL;
+    node->inferred_type.kind = TY_INT;
+    node->inferred_type.info.dec.a = 0;
+    node->inferred_type.info.dec.b = 0;
     
     return node;
 }

--- a/src/semantics.c
+++ b/src/semantics.c
@@ -1,34 +1,166 @@
 #include "semantics.h"
 #include "memmgr.h"
 #include <stdio.h>
+#include <string.h>
 
-static void analyze_node(SemaContext *sc, ASTNode *node) {
-    if (!node) return;
+/* Cria um tipo básico com metadados zerados */
+static Type make_type(TypeKind kind) {
+    Type t;
+    t.kind = kind;
+    if (kind == TY_DEC) {
+        t.info.dec.a = 0;
+        t.info.dec.b = 0;
+    } else if (kind == TY_TXT) {
+        t.info.txt.n = 0;
+    } else {
+        memset(&t.info, 0, sizeof(t.info));
+    }
+    return t;
+}
+
+/* Infere o tipo de uma expressão e anota no nó */
+static Type resolve_expr_type(SemaContext *sc, ASTNode *node) {
+    Type t = make_type(TY_INT);
+    if (!node) return t;
 
     switch (node->type) {
-        case AST_DECLARATION:
-            if (node->child_count > 0) {
-                ASTNode *id = node->children[0];
-                if (id && id->type == AST_IDENTIFIER && id->token.lexeme) {
-                    Symbol s = {0};
-                    s.name = id->token.lexeme;
-                    s.sclass = SYM_VAR;
-                    s.type = NULL;
-                    s.line_decl = id->token.line;
-                    s.extra = NULL;
-                    symtab_insert(sc->symtab, &s);
-                }
+        case AST_LITERAL:
+            switch (node->token.type) {
+                case TOK_INTEGER_LITERAL:
+                    t = make_type(TY_INT);
+                    break;
+                case TOK_DECIMAL_LITERAL:
+                    t = make_type(TY_DEC);
+                    if (node->token.lexeme) {
+                        const char *dot = strchr(node->token.lexeme, '.');
+                        if (dot) {
+                            t.info.dec.a = (int)(dot - node->token.lexeme);
+                            t.info.dec.b = (int)strlen(dot + 1);
+                        } else {
+                            t.info.dec.a = (int)strlen(node->token.lexeme);
+                            t.info.dec.b = 0;
+                        }
+                    }
+                    break;
+                case TOK_STRING_LITERAL:
+                    t = make_type(TY_TXT);
+                    if (node->token.lexeme) {
+                        size_t len = strlen(node->token.lexeme);
+                        if (len >= 2) len -= 2; /* remove aspas */
+                        t.info.txt.n = len;
+                    }
+                    break;
+                default:
+                    break;
             }
             break;
+
+        case AST_IDENTIFIER: {
+            Symbol *sym = symtab_lookup(sc->symtab, node->token.lexeme);
+            if (sym && sym->type) t = *sym->type;
+            break;
+        }
+
+        case AST_BINARY_OP: {
+            Type left = resolve_expr_type(sc, node->children[0]);
+            Type right = resolve_expr_type(sc, node->children[1]);
+            switch (node->token.type) {
+                case TOK_PLUS:
+                case TOK_MINUS:
+                case TOK_STAR:
+                case TOK_SLASH:
+                case TOK_MODULO:
+                case TOK_CARET:
+                    if (left.kind == TY_DEC || right.kind == TY_DEC)
+                        t = make_type(TY_DEC);
+                    else
+                        t = make_type(TY_INT);
+                    break;
+                case TOK_EQ:
+                case TOK_NEQ:
+                case TOK_LT:
+                case TOK_GT:
+                case TOK_LE:
+                case TOK_GE:
+                    t = make_type(TY_BOOL);
+                    break;
+                case TOK_AND:
+                case TOK_OR:
+                    t = make_type(TY_BOOL);
+                    break;
+                default:
+                    t = make_type(TY_INT);
+                    break;
+            }
+            break;
+        }
+
+        case AST_UNARY_OP:
+            if (node->child_count > 0)
+                t = resolve_expr_type(sc, node->children[0]);
+            break;
+
+        case AST_EXPRESSION:
+            if (node->child_count > 0)
+                t = resolve_expr_type(sc, node->children[0]);
+            break;
+
         default:
             break;
     }
 
-    {
-        int i;
-        for (i = 0; i < node->child_count; i++) {
-            analyze_node(sc, node->children[i]);
+    node->inferred_type = t;
+    return t;
+}
+
+/* Analisa os nós da AST e resolve tipos */
+static void analyze_node(SemaContext *sc, ASTNode *node) {
+    if (!node) return;
+
+    switch (node->type) {
+        case AST_DECLARATION: {
+            TypeKind kind = TY_INT;
+            switch (node->token.type) {
+                case TOK_KW_DECIMAL: kind = TY_DEC; break;
+                case TOK_KW_TEXTO:   kind = TY_TXT; break;
+                case TOK_KW_INTEIRO: default: kind = TY_INT; break;
+            }
+
+            int i;
+            for (i = 0; i < node->child_count; i++) {
+                ASTNode *child = node->children[i];
+                if (child->type == AST_IDENTIFIER && child->token.lexeme) {
+                    Type *t = (Type*)mm_malloc(sizeof(Type));
+                    if (t) *t = make_type(kind);
+                    Symbol s = {0};
+                    s.name = child->token.lexeme;
+                    s.sclass = SYM_VAR;
+                    s.type = t;
+                    s.line_decl = child->token.line;
+                    s.extra = NULL;
+                    symtab_insert(sc->symtab, &s);
+                } else {
+                    analyze_node(sc, child);
+                }
+            }
+            return;
         }
+
+        case AST_BINARY_OP:
+        case AST_LITERAL:
+        case AST_IDENTIFIER:
+        case AST_UNARY_OP:
+        case AST_EXPRESSION:
+            resolve_expr_type(sc, node);
+            return;
+
+        default:
+            break;
+    }
+
+    int i;
+    for (i = 0; i < node->child_count; i++) {
+        analyze_node(sc, node->children[i]);
     }
 }
 

--- a/src/symtab.c
+++ b/src/symtab.c
@@ -148,10 +148,22 @@ static const char* class_str(SymClass c) {
 static const char* type_str(const Type *t) {
     if (!t) return "?";
     switch (t->kind) {
-        case TYPE_INT:   return "int";
-        case TYPE_FLOAT: return "float";
-        case TYPE_VOID:  return "void";
-        default:         return "?";
+        case TY_INT:
+            return "int";
+        case TY_DEC: {
+            static char buf[32];
+            sprintf(buf, "decimal[%d.%d]", t->info.dec.a, t->info.dec.b);
+            return buf;
+        }
+        case TY_TXT: {
+            static char buf[32];
+            sprintf(buf, "texto[%zu]", t->info.txt.n);
+            return buf;
+        }
+        case TY_BOOL:
+            return "bool";
+        default:
+            return "?";
     }
 }
 


### PR DESCRIPTION
## Summary
- add new `Type` definitions for ints, decimals, text and bools with metadata
- annotate AST nodes with inferred types and implement semantic inference rules
- extend symbol table printing for new type forms

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68ae79a3a490832baf9b9d4e39bce2f1