### PR TITLE
Add semantics context printer for symbol table

### DIFF
--- a/include/semantics.h
+++ b/include/semantics.h
@@ -14,6 +14,8 @@ typedef struct {
 
 SemaContext* sema_create(size_t mem_limit_bytes);
 bool semantic_analyze(SemaContext* sc, ASTNode* ast);
+/* Imprime a tabela de símbolos acumulada e relatório de memória. */
+void symtab_print(SemaContext* sc);
 void sema_destroy(SemaContext* sc);
 
 #endif /* SEMANTICS_H */

--- a/include/symtab.h
+++ b/include/symtab.h
@@ -46,7 +46,8 @@ void symtab_leave_scope(SymTab *st);
 bool symtab_insert(SymTab *st, const Symbol *sym);
 Symbol* symtab_lookup(SymTab *st, const char *name);
 
-void symtab_print(SymTab *st);
+/* Imprime a tabela de símbolos. Usado internamente pela camada semântica. */
+void symtab_dump(SymTab *st);
 
 #endif /* SYMTAB_H */
 

--- a/src/main.c
+++ b/src/main.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
     } else {
         printf("\033[32mAnálise semântica concluída com sucesso!\033[0m\n");
     }
-    symtab_print(sc->symtab);
+    symtab_print(sc);
     sema_destroy(sc);
 
     /* Limpeza da AST */

--- a/src/semantics.c
+++ b/src/semantics.c
@@ -378,6 +378,12 @@ bool semantic_analyze(SemaContext* sc, ASTNode* ast) {
     return true;
 }
 
+/* Wrapper para exibir a tabela de símbolos associada ao contexto. */
+void symtab_print(SemaContext* sc) {
+    if (!sc) return;
+    symtab_dump(sc->symtab);
+}
+
 void sema_destroy(SemaContext* sc) {
     if (!sc) return;
     symtab_destroy(sc->symtab);

--- a/src/symtab.c
+++ b/src/symtab.c
@@ -164,7 +164,10 @@ static const char* type_str(const Type *t) {
     }
 }
 
-void symtab_print(SymTab *st) {
+/* Imprime todo o conteúdo da tabela de símbolos, preservando a ordem de
+   criação de escopos. A função também reporta o pico de memória observado
+   pelo gerenciador. */
+void symtab_dump(SymTab *st) {
     if (!st) return;
 
     size_t count = 0;


### PR DESCRIPTION
## Summary
- Expose `symtab_print` wrapper on `SemaContext` and rename internal dump implementation
- Update `main` to use the new API

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ae75982790832b8bd55f22d93f0075