### PR TITLE
Add test for declaration inside se block

### DIFF
--- a/tests/decl_inside_se.src
+++ b/tests/decl_inside_se.src
@@ -1,0 +1,6 @@
+principal(){
+    inteiro !a;
+    se (!a == 0) {
+        inteiro !b;
+    }
+}


### PR DESCRIPTION
## Summary
- add test case with a variable declared inside a `se` block to trigger semantic analysis warnings

## Testing
- `make test >/tmp/test.log && tail -n 20 /tmp/test.log`
- `cat tests/decl_inside_se.src.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae9e2f9260832b874a1cb62d9b9c18