### PR TITLE
Fix principal detection and warn on block declarations

### DIFF
--- a/src/semantics.c
+++ b/src/semantics.c
@@ -155,6 +155,14 @@ static void analyze_node(SemaContext *sc, ASTNode *node, ASTNodeType parent) {
             return;
         }
 
+        case AST_BLOCK: {
+            int i;
+            for (i = 0; i < node->child_count; i++) {
+                analyze_node(sc, node->children[i], parent);
+            }
+            return;
+        }
+
         case AST_ASSIGNMENT: {
             if (node->child_count >= 2) {
                 ASTNode *lhs = node->children[0];
@@ -306,6 +314,12 @@ static void analyze_function(SemaContext *sc, ASTNode *func) {
 static int build_function_index(SemaContext *sc, ASTNode *program, ASTNode **funcs) {
     int count = 0;
     int principal_count = 0;
+
+    /* O nó raiz representa implicitamente a função principal() */
+    if (program->token.lexeme && strcmp(program->token.lexeme, "principal") == 0) {
+        principal_count = 1;
+    }
+
     int i;
     for (i = 0; i < program->child_count; i++) {
         ASTNode *child = program->children[i];

--- a/tests/decl_inside_se.src.log
+++ b/tests/decl_inside_se.src.log
@@ -1,0 +1,54 @@
+[32mLimite máximo de memória: 2097152 bytes[0m
+[33mAlerta semântico (linha 4): declaração fora de escopo permitido[0m
+[34m=== ANÁLISE LÉXICA ===[0m
+   1: TOK_KW_PRINCIPAL 'principal'
+   1: TOK_LPAREN      '('
+   1: TOK_RPAREN      ')'
+   1: TOK_LBRACE      '{'
+   2: TOK_KW_INTEIRO  'inteiro'
+   2: TOK_IDENTIFIER  '!a'
+   2: TOK_SEMICOLON   ';'
+   3: TOK_KW_SE       'se'
+   3: TOK_LPAREN      '('
+   3: TOK_IDENTIFIER  '!a'
+   3: TOK_EQ          '=='
+   3: TOK_INTEGER_LITERAL '0'
+   3: TOK_RPAREN      ')'
+   3: TOK_LBRACE      '{'
+   4: TOK_KW_INTEIRO  'inteiro'
+   4: TOK_IDENTIFIER  '!b'
+   4: TOK_SEMICOLON   ';'
+   5: TOK_RBRACE      '}'
+   6: TOK_RBRACE      '}'
+   7: TOK_EOF         ''
+[32mAnálise léxica concluída com sucesso![0m
+
+[34m=== ANÁLISE SINTÁTICA ===[0m
+[32mAnálise sintática concluída com sucesso![0m
+
+[34m=== VALIDAÇÕES SINTÁTICAS ===[0m
+[32m✓ Sequência de declarações válida[0m
+[32m✓ Regras de espaçamento respeitadas[0m
+[32m✓ Uso de variáveis válido[0m
+
+[34m=== ÁRVORE SINTÁTICA ABSTRATA ===[0m
+PROGRAM 'principal'
+  DECLARATION 'inteiro'
+    IDENTIFIER '!a'
+  IF_STMT 'se'
+    BINARY_OP '=='
+      IDENTIFIER '!a'
+      LITERAL '0'
+    BLOCK '{'
+      DECLARATION 'inteiro'
+        IDENTIFIER '!b'
+[32mAnálise semântica concluída com sucesso![0m
+Escopo 0:
+  !a (var, int, linha 2)
+  !b (var, int, linha 4)
+
+Pico de memória: 2460 bytes (inteiro=4B, decimal=8B, texto[n]=nB)
+
+[34m=== RELATÓRIO DE MEMÓRIA ===[0m
+Uso atual: 438 bytes
+Pico de uso: 2460 bytes


### PR DESCRIPTION
## Summary
- prevent false missing principal() warnings by recognizing the root program as the implicit main function
- flag variable declarations inside control-flow blocks such as `se` by propagating context through blocks
- add regression log for declaration-inside-`se` test

## Testing
- `make`
- `./compiler tests/decl_inside_se.src`


------
https://chatgpt.com/codex/tasks/task_e_68aea3ef2c54832b8daf07d19e611085